### PR TITLE
add support for macOS Sierra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ MANDIR=		$(PREFIX)/man/man1
 PROG=	ftp
 MAN1=	ftp.1
 SRCS=	cmds.c cmdtab.c complete.c cookie.c domacro.c fetch.c ftp.c \
-	list.c main.c ruserpass.c small.c stringlist.c util.c
+	list.c main.c ruserpass.c small.c stringlist.c util.c strtonum.c
 OBJS=	cmds.o cmdtab.o complete.o cookie.o domacro.o fetch.o ftp.o \
-	list.o main.o ruserpass.o small.o stringlist.o util.o
+	list.o main.o ruserpass.o small.o stringlist.o util.o strtonum.o
 LIBS=	-ledit -lcurses -lutil -ltls -lssl -lcrypto
 LIBS+=	-lresolv # b64_ntop()
 

--- a/cmds.c
+++ b/cmds.c
@@ -84,6 +84,7 @@
 #include "ftp_var.h"
 #include "pathnames.h"
 #include "cmds.h"
+#include "strtonum.h"
 
 /*
  * Set ascii transfer type.

--- a/cookie.c
+++ b/cookie.c
@@ -30,6 +30,7 @@
 #include <time.h>
 
 #include "ftp_var.h"
+#include "strtonum.h"
 
 struct cookie {
 	TAILQ_ENTRY(cookie)	 entry;

--- a/fetch.c
+++ b/fetch.c
@@ -215,6 +215,11 @@ url_get(const char *origline, const char *proxyenv, const char *outfile, int las
 	direction = "received";
 
 	newline = strdup(origline);
+
+    /* Ignore any trailing `fragment' from the HTTP URL.
+     * Fragments (HTML anchors) are identified by a hash char ('#'),
+     * as per RFC 3986. */
+    newline = strsep(&newline, "#");
 	if (newline == NULL)
 		errx(1, "Can't allocate memory to parse URL");
 	if (strncasecmp(newline, HTTP_URL, sizeof(HTTP_URL) - 1) == 0) {

--- a/fetch.c
+++ b/fetch.c
@@ -66,6 +66,7 @@ struct tls;
 
 #include "ftp_var.h"
 #include "cmds.h"
+#include "strtonum.h"
 
 static int	url_get(const char *, const char *, const char *, int);
 void		aborthttp(int);

--- a/main.c
+++ b/main.c
@@ -79,6 +79,7 @@
 
 #include "cmds.h"
 #include "ftp_var.h"
+#include "strtonum.h"
 
 int connect_timeout;
 

--- a/small.c
+++ b/small.c
@@ -82,6 +82,7 @@
 #include "ftp_var.h"
 #include "pathnames.h"
 #include "small.h"
+#include "strtonum.h"
 
 jmp_buf	jabort;
 char   *mname;

--- a/strtonum.c
+++ b/strtonum.c
@@ -1,0 +1,67 @@
+/*	$OpenBSD: strtonum.c,v 1.6 2004/08/03 19:38:01 millert Exp $	*/
+
+/*
+ * Copyright (c) 2004 Ted Unangst and Todd Miller
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
+#include "strtonum.h"
+
+#define INVALID 	1
+#define TOOSMALL 	2
+#define TOOLARGE 	3
+
+long long
+strtonum(const char *numstr, long long minval, long long maxval,
+    const char **errstrp)
+{
+	long long ll = 0;
+	char *ep;
+	int error = 0;
+	struct errval {
+		const char *errstr;
+		int err;
+	} ev[4] = {
+		{ NULL,		0 },
+		{ "invalid",	EINVAL },
+		{ "too small",	ERANGE },
+		{ "too large",	ERANGE },
+	};
+
+	ev[0].err = errno;
+	errno = 0;
+	if (minval > maxval)
+		error = INVALID;
+	else {
+		ll = strtoll(numstr, &ep, 10);
+		if (numstr == ep || *ep != '\0')
+			error = INVALID;
+		else if ((ll == LLONG_MIN && errno == ERANGE) || ll < minval)
+			error = TOOSMALL;
+		else if ((ll == LLONG_MAX && errno == ERANGE) || ll > maxval)
+			error = TOOLARGE;
+	}
+	if (errstrp != NULL)
+		*errstrp = ev[error].errstr;
+	errno = ev[error].err;
+	if (error)
+		ll = 0;
+
+	return (ll);
+}

--- a/strtonum.h
+++ b/strtonum.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2011 Eric P. Mangold
+ *
+ * See LICENSE.txt for details. */
+
+#ifndef _STRTONUM_H
+#define _STRTONUM_H
+
+#include <limits.h>
+
+/* some crappy GCC versions of limits.h don't define these */
+#ifndef LLONG_MIN
+#define LLONG_MIN      (-0x7fffffffffffffffLL-1)
+#endif
+
+#ifndef LLONG_MAX
+#define LLONG_MAX      0x7fffffffffffffffLL
+#endif
+
+long long
+strtonum(const char *numstr, long long minval, long long maxval,
+    const char **errstrp);
+
+#endif

--- a/util.c
+++ b/util.c
@@ -89,6 +89,16 @@
 #include "ftp_var.h"
 #include "pathnames.h"
 
+#define	timespecsub(tsp, usp, vsp)					\
+	do {								\
+		(vsp)->tv_sec = (tsp)->tv_sec - (usp)->tv_sec;		\
+		(vsp)->tv_nsec = (tsp)->tv_nsec - (usp)->tv_nsec;	\
+		if ((vsp)->tv_nsec < 0) {				\
+			(vsp)->tv_sec--;				\
+			(vsp)->tv_nsec += 1000000000L;			\
+		}							\
+	} while (0)
+
 #define MINIMUM(a, b)	(((a) < (b)) ? (a) : (b))
 #define MAXIMUM(a, b)	(((a) > (b)) ? (a) : (b))
 


### PR DESCRIPTION
These are the changes I made to support compilation on macOS Sierra - strtonum function was something I previously ported from openbsd source for another project, and I've copied the files here, since it doesn't appear to be on my system.. even though your port mentions mac os x... I'm not sure that was supposed to work, but oh well, this is working nicely for me - but if you type 'help' in the interactive `ftp' prompt it prints a couple lines then segfaults :( just fyi